### PR TITLE
Depth statue

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -2,6 +2,7 @@ import sqlite3 from 'better-sqlite3';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
+import { Beco } from './beco';
 
 let parseArgs = require('minimist');
 let argv = parseArgs(process.argv);
@@ -84,6 +85,16 @@ const DROP_TYPE_ACTOR = "Actor";
 const DROP_TYPE_TABLE = "Table";
 
 
+const BecoGround = new Beco('Ground.beco');
+const BecoMinus = new Beco('MinusField.beco');
+const BecoSky = new Beco('Sky.beco');
+const BecoCave = new Beco('Cave.beco');
+
+const Ecosystem = Object.fromEntries(['Cave', 'Ground', 'MinusField', 'Sky'].map(name => {
+  return [name, JSON.parse(fs.readFileSync(`${name}.ecocat.json`, 'utf8')).RootNode];
+}));
+
+
 const insertObj = db.prepare(`INSERT INTO objs
   (map_type, map_name, gen_group, hash_id, unit_config_name, ui_name, data, scale, map_static, drops, equip, merged, ui_drops, ui_equip, korok_id, korok_type)
   VALUES
@@ -150,6 +161,17 @@ export function pointToMapUnit(p: number[]) {
     + String.fromCharCode('1'.charCodeAt(0) + row);
 }
 
+function getEcosystemArea(name: string, num: number) {
+  if (Ecosystem[name][num].AreaNumber == num) {
+    return Ecosystem[name][num];
+  }
+  for (const area of Ecosystem[name]) {
+    if (area.AreaNumber == num) {
+      return area;
+    }
+  }
+  return null;
+}
 
 function getMapNameForOpenWorldStage(filePath: string) {
   // Almost everything, except MinusField must come before MainField
@@ -328,6 +350,7 @@ function processBanc(filePath: string, mapType: string, mapName: string) {
         ui_name += ' ' + LOCATIONS[dyn.Location];
       }
     }
+
     // If DropTable and DropActor do not exist and an blank drop exists
     //   set the DropTable name to as 'Default'
     if (Object.keys(drops).length == 0) {
@@ -340,6 +363,28 @@ function processBanc(filePath: string, mapType: string, mapName: string) {
       }
     }
 
+    if (actor.Gyaml == 'Npc_MinusFieldGhost_000') {
+      const num = BecoMinus.getCurrentAreaNum(actor.Translate[0], actor.Translate[2]);
+      const area = getEcosystemArea('MinusField', num);
+      let weapon_type = actor.Dynamic?.HoldingWeaponType || 1;
+      let weapons = []
+      if (weapon_type == 1) {
+        // Royal Broadsword ( 0x83ba246d992d663b)
+        // Eightfold Blade (  0x70f7cb89ab7052e0)
+        weapons = area.NotDecayedSmallSwordList;
+      } else if (weapon_type == 2) {
+        // Royal Guards Claymore ( 0x0a73b302f59153b7)
+        // Traveler's Claymore ( 0xec225a9dfda4679e)
+        weapons = area.NotDecayedLargeSwordList;
+      } else if (weapon_type == 3) {
+        // Knight's Halberd ( 0x0cde450be4231a97)
+        // Travelers Spear (  0x0e4718a9b20afa93)
+        weapons = area.NotDecayedSpearList;
+      }
+      const names = weapons.map((weapon: any) => weapon.name);
+      equip.push(...names);
+      ui_equip.push(...names.map((name: string) => getName(name)));
+    }
 
     if (mapType === "Totk" && mapName.includes('Z-0')) {
       const level = mapName.split('_')[0];

--- a/build.ts
+++ b/build.ts
@@ -6,12 +6,17 @@ import { Beco } from './beco';
 
 let parseArgs = require('minimist');
 let argv = parseArgs(process.argv);
-if (!argv.d) {
-  console.log("Error: Must specify a path to directory with Banc extracted YAML files");
-  console.log("       e.g. % ts-node build.ts -d path/to/Banc")
+if (!argv.d || !argv.b || !argv.e) {
+  console.log("Error: Must specify paths to directories with ");
+  console.log("          -d Banc extracted YAML files");
+  console.log("          -b field map area beco files");
+  console.log("          -e Ecosystem json files");
+  console.log("       e.g. % ts-node build.ts -d path/to/Banc -b path/to/beco -e path/to/Ecosystem")
   process.exit(1);
 }
 const totkData = argv.d
+const becoPath = argv.b;
+const ecoPath = argv.e;
 
 fs.rmSync('map.db.tmp', { force: true });
 const db = sqlite3('map.db.tmp');
@@ -85,13 +90,14 @@ const DROP_TYPE_ACTOR = "Actor";
 const DROP_TYPE_TABLE = "Table";
 
 
-const BecoGround = new Beco('Ground.beco');
-const BecoMinus = new Beco('MinusField.beco');
-const BecoSky = new Beco('Sky.beco');
-const BecoCave = new Beco('Cave.beco');
+const BecoGround = new Beco(path.join(becoPath, 'Ground.beco'));
+const BecoMinus = new Beco(path.join(becoPath, 'MinusField.beco'));
+const BecoSky = new Beco(path.join(becoPath, 'Sky.beco'));
+const BecoCave = new Beco(path.join(becoPath, 'Cave.beco'));
 
+// Should probably be yaml not json for consistency
 const Ecosystem = Object.fromEntries(['Cave', 'Ground', 'MinusField', 'Sky'].map(name => {
-  return [name, JSON.parse(fs.readFileSync(`${name}.ecocat.json`, 'utf8')).RootNode];
+  return [name, JSON.parse(fs.readFileSync(path.join(ecoPath, `${name}.ecocat.json`), 'utf8')).RootNode];
 }));
 
 

--- a/tools/Cave.ecocat.json
+++ b/tools/Cave.ecocat.json
@@ -1,0 +1,10583 @@
+{
+  "byteOrder": 65534,
+  "Version": 4,
+  "RootNode": [
+    {
+      "Area": "",
+      "AreaNumber": 0,
+      "Climate": "GerudoFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 1,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 2,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 3,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 4,
+      "Climate": "GerudoPlateauClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 5,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 6,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 7,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 8,
+      "Climate": "LostWoodClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 9,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 10,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 11,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 12,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 13,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 14,
+      "Climate": "KorogForest",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 15,
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 16,
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 17,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 18,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 19,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 20,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 21,
+      "Climate": "GerudoDesertClimateLv2",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 22,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 23,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 24,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 25,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 26,
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 27,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 28,
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 29,
+      "Climate": "FiloneSubtropicalClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetSubtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 30,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 31,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 32,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 33,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 34,
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_Z",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 35,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 36,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 37,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 38,
+      "Climate": "FrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 39,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 40,
+      "Climate": "GerudoDesertClimateLv2",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 41,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 42,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 43,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 44,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 45,
+      "Climate": "GerudoFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 46,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 47,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 48,
+      "Climate": "HebraFrostClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 49,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 50,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 51,
+      "Climate": "EldinClimateLv0",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 52,
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 53,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_033"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 54,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 55,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 56,
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_Z",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 57,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 58,
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 59,
+      "Climate": "FiloneSubtropicalClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetSubtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 60,
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 61,
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 62,
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 63,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 64,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 65,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 66,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 67,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 68,
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_Z",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 69,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 70,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 71,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 72,
+      "Climate": "GerudoDesertClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 73,
+      "Climate": "GerudoPlateauClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 74,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 75,
+      "Climate": "TamourPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 76,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 77,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 78,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 79,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 80,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 81,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie.game__location__Location.gyml",
+      "AreaNumber": 82,
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 83,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 84,
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_Z",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 85,
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_Z",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 86,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 87,
+      "Climate": "GerudoDesertClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 90.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 1.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 88,
+      "Climate": "DarkWoodsClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 89,
+      "Climate": "EldinClimateLv0",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 90,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 91,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 92,
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 100.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 93,
+      "Climate": "HateruPlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "",
+      "AreaNumber": 94,
+      "Climate": "TabantaAridClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 80.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AC",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AH",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AC",
+          "num": 10.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    }
+  ]
+}

--- a/tools/Ground.ecocat.json
+++ b/tools/Ground.ecocat.json
@@ -1,0 +1,29991 @@
+{
+  "byteOrder": 65534,
+  "Version": 4,
+  "RootNode": [
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 0,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "GerudoFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId000.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_WestHateru.game__location__Location.gyml",
+      "AreaNumber": 1,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 4.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId001.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 2,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId002.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 3,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId003.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 4,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoPlateauClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId004.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 5,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 3.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 3.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId005.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 6,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId006.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 7,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 3.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId007.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleForest.game__location__Location.gyml",
+      "AreaNumber": 8,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId008.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 9,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId003.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyliaLake.game__location__Location.gyml",
+      "AreaNumber": 10,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId010.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWaterSources.game__location__Location.gyml",
+      "AreaNumber": 11,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId011.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 12,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 13,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId013.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleForest.game__location__Location.gyml",
+      "AreaNumber": 14,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId014.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 15,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId015.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleForest.game__location__Location.gyml",
+      "AreaNumber": 16,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId016.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 17,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 3.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId017.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 18,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_WestHateru.game__location__Location.gyml",
+      "AreaNumber": 19,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId019.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulOutback.game__location__Location.gyml",
+      "AreaNumber": 20,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId020.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoDesert.game__location__Location.gyml",
+      "AreaNumber": 21,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoDesertClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Electric",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 8.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 50.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Gerudo",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulOutback.game__location__Location.gyml",
+      "AreaNumber": 22,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 23,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId023.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 24,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 10.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId024.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 25,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId025.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 26,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId026.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 27,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId027.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bull_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HateruSea.game__location__Location.gyml",
+      "AreaNumber": 28,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId028.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 29,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "FiloneSubtropicalClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "WetSubtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId029.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulSea.game__location__Location.gyml",
+      "AreaNumber": 30,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 31,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId031.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 32,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId006.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 33,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "Ichikara_Climate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId033.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWaterSources.game__location__Location.gyml",
+      "AreaNumber": 34,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 4.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId034.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 35,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId076.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 36,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 10.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId036.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 37,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LiveMountain.game__location__Location.gyml",
+      "AreaNumber": 38,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "FrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId038.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 39,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId003.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoDesert.game__location__Location.gyml",
+      "AreaNumber": 40,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoDesertClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Electric",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 50.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Gerudo",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 41,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 42,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId042.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea.game__location__Location.gyml",
+      "AreaNumber": 43,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Middle",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_DeathMountain.game__location__Location.gyml",
+      "AreaNumber": 44,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId044.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 45,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "GerudoCanyon",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Fire_GerudoCanyon_PopUp",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice_GerudoCanyon_Popup",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 9.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 46,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 3.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId046.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 9.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 47,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "BeginningPlateauFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 48,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId031.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_WestHateru.game__location__Location.gyml",
+      "AreaNumber": 49,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 9.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 50,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId050.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 51,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 52,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 53,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulSea.game__location__Location.gyml",
+      "AreaNumber": 54,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Senior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeSea.game__location__Location.gyml",
+      "AreaNumber": 55,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 56,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 4.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruSea.game__location__Location.gyml",
+      "AreaNumber": 57,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea.game__location__Location.gyml",
+      "AreaNumber": 58,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Gull_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Middle",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_F",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_G",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId055.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_F",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_G",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bull_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_WestHateru.game__location__Location.gyml",
+      "AreaNumber": 59,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "FiloneSubtropicalClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "WetSubtropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId059.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleForest.game__location__Location.gyml",
+      "AreaNumber": 60,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bull_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 61,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId061.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bull_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 62,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Middle",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId062.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleHill.game__location__Location.gyml",
+      "AreaNumber": 63,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 12.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId063.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 10.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 10.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill.game__location__Location.gyml",
+      "AreaNumber": 64,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Crow_A",
+          "num": 10.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId064.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWetlands.game__location__Location.gyml",
+      "AreaNumber": 65,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId065.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 66,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 3.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId044.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 67,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 3.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId044.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWaterSources.game__location__Location.gyml",
+      "AreaNumber": 68,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId068.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWetlands.game__location__Location.gyml",
+      "AreaNumber": 69,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 70,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId006.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 71,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId071.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoDesert.game__location__Location.gyml",
+      "AreaNumber": 72,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoDesertClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Electric",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 8.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 50.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Gerudo",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId072.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 73,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoCanyon",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Fire_GerudoCanyon_PopUp",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice_GerudoCanyon_Popup",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 40.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 10.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 74,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 10.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId074.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 75,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Gull_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId075.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 76,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId076.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleHill.game__location__Location.gyml",
+      "AreaNumber": 77,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId064.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 78,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId078.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 79,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "HyruleCastle",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId076.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 80,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleHill.game__location__Location.gyml",
+      "AreaNumber": 81,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 12.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 10.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 10.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 6.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_CentralHyrule.game__location__Location.gyml",
+      "AreaNumber": 82,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Swarm",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 83,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWaterSources.game__location__Location.gyml",
+      "AreaNumber": 84,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 4.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_LanayruWaterSources.game__location__Location.gyml",
+      "AreaNumber": 85,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "ZoraTemperateClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 4.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_D",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 25.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_D",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 86,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoDesert.game__location__Location.gyml",
+      "AreaNumber": 87,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoDesertClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_TBox"
+            }
+          ],
+          "name": "Enemy_Octarock_Desert",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 8.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 50.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Gerudo",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId087.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HyruleForest.game__location__Location.gyml",
+      "AreaNumber": 88,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_02"
+            },
+            {
+              "name": "OctObj_Grass_03"
+            },
+            {
+              "name": "OctObj_Grass_04"
+            },
+            {
+              "name": "OctObj_Grass_05"
+            },
+            {
+              "name": "OctObj_Grass_06"
+            },
+            {
+              "name": "OctObj_Grass_07"
+            }
+          ],
+          "name": "Enemy_Octarock_Forest",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId016.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 89,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_FironeGrassland.game__location__Location.gyml",
+      "AreaNumber": 90,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Gull_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId090.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 91,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId007.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 92,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId007.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_WestHateru.game__location__Location.gyml",
+      "AreaNumber": 93,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 3.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 1.0
+        }
+      ],
+      "Climate": "HateruPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 6.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId093.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 94,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Climate": "GerudoCanyon_BufferZone",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 95,
+      "Climate": "GerudoPlateauClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 96,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "NorthHyrulePlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId015.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 7.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 97,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 5.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_X",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinMountains.game__location__Location.gyml",
+      "AreaNumber": 98,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_X",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 150.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_X",
+          "num": 20.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 99,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 3.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId005.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 100,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 3.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId005.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 101,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId003.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 0.5
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TabantaFrontier.game__location__Location.gyml",
+      "AreaNumber": 102,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 5.0
+        }
+      ],
+      "Climate": "TabantaAridClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_D",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_C",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId042.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_D",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_C",
+          "num": 8.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Squirrel_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Boar_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 1.5
+        },
+        {
+          "name": "Animal_Bear_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Boar_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 5.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_TamulPlateau.game__location__Location.gyml",
+      "AreaNumber": 103,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_LittleBird_C",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Heron_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_LittleBird_A",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "TamourPlainClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Assassin_Middle",
+          "num": 1.0,
+          "weapons": [
+            {
+              "name": "Weapon_Lsword_114",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_L",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Fish_M",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Fish_H",
+          "num": 3.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 20.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId002.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_L",
+          "num": 4.0
+        },
+        {
+          "name": "Item_FishGet_M",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        },
+        {
+          "name": "Item_FishGet_H",
+          "num": 3.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bull_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_WildGoat_A",
+          "num": 4.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EastHateru.game__location__Location.gyml",
+      "AreaNumber": 104,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 5.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_D",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "SouthHateruHumidTempClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_01"
+            }
+          ],
+          "name": "Enemy_Octarock",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_A",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        },
+        {
+          "name": "Item_Material_03",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_K",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_AG",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_O",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_024"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_024"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_024"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId061.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_A",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Cassowary_A",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Wolf_A",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fox_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_EldinCanyon.game__location__Location.gyml",
+      "AreaNumber": 105,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_LittleBird_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "EldinClimateLv0",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Fire",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Stone_Crack_01"
+            }
+          ],
+          "name": "Enemy_Octarock_Stone",
+          "num": 3.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 40.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_J",
+          "num": 15.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_AB",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_X",
+          "num": 16.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 6.0
+        }
+      ],
+      "JunkBoxMgrParam": "None",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId044.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_J",
+          "num": 15.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Wolf_B",
+          "num": 2.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_GerudoHighlands.game__location__Location.gyml",
+      "AreaNumber": 106,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "GerudoCanyon",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Electric",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 10.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 30.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_S",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId004.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Animal": [
+        {
+          "name": "Animal_Bear_B",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Wolf_C",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Elk_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Deer_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Doe_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Fox_B",
+          "num": 3.0
+        }
+      ],
+      "Area": "Work/Location/MapArea_HeburaMountains.game__location__Location.gyml",
+      "AreaNumber": 107,
+      "AutoPlacementMaterial": [
+        {
+          "name": "BrokenSnowBall",
+          "num": 10.0
+        },
+        {
+          "name": "Weapon_Sword_044",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_LittleBird_B",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraFrostClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Keese_Ice",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 1.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_040",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Assassin_Shooter_Junior",
+          "num": 1.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Lizalfos_Ice",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 2.0
+        },
+        {
+          "helmets": [
+            {
+              "name": "OctObj_Grass_08"
+            }
+          ],
+          "name": "Enemy_Octarock_Snow",
+          "num": 2.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 30.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 70.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_C",
+          "num": 12.0
+        },
+        {
+          "name": "Animal_Fish_I",
+          "num": 1.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_A",
+          "num": 120.0
+        },
+        {
+          "name": "Item_Material_07",
+          "num": 50.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Often",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "Work/Grass/ResTeraMatOverwrite/Prequel_EcoId003.game__grass__ResTeraMatOverwrite.gyml",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_C",
+          "num": 12.0
+        },
+        {
+          "name": "Item_FishGet_I",
+          "num": 1.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    }
+  ]
+}

--- a/tools/MinusField.ecocat.json
+++ b/tools/MinusField.ecocat.json
@@ -1,0 +1,17462 @@
+{
+  "byteOrder": 65534,
+  "Version": 4,
+  "RootNode": [
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 0,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        },
+        {
+          "name": "Weapon_Lsword_047"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        },
+        {
+          "name": "Weapon_Sword_047"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_047"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 1,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 2,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 3,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 4,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 5,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 6,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 7,
+      "Climate": "EldinUnderGroundClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Underground.game__location__Location.gyml",
+      "AreaNumber": 8,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 9,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/LakeHylia_Underground.game__location__Location.gyml",
+      "AreaNumber": 10,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Underground.game__location__Location.gyml",
+      "AreaNumber": 11,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 12,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 13,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Underground.game__location__Location.gyml",
+      "AreaNumber": 14,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 15,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Underground.game__location__Location.gyml",
+      "AreaNumber": 16,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 17,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 18,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 19,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulOutback_Underground.game__location__Location.gyml",
+      "AreaNumber": 20,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Underground.game__location__Location.gyml",
+      "AreaNumber": 21,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 6.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulOutback_Underground.game__location__Location.gyml",
+      "AreaNumber": 22,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 23,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 24,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 25,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 26,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 27,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 28,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        },
+        {
+          "name": "Weapon_Lsword_047"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        },
+        {
+          "name": "Weapon_Sword_047"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_047"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 29,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 30,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        },
+        {
+          "name": "Weapon_Lsword_047"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        },
+        {
+          "name": "Weapon_Sword_047"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_047"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 31,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 32,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 33,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Underground.game__location__Location.gyml",
+      "AreaNumber": 34,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 35,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 36,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 37,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LiveMountain_Underground.game__location__Location.gyml",
+      "AreaNumber": 38,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 39,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Underground.game__location__Location.gyml",
+      "AreaNumber": 40,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 6.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 41,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        },
+        {
+          "name": "Weapon_Lsword_047"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        },
+        {
+          "name": "Weapon_Sword_047"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_047"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 42,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 43,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_DeathMountain_Underground.game__location__Location.gyml",
+      "AreaNumber": 44,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 45,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 46,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 47,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 48,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 49,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 50,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 51,
+      "Climate": "EldinUnderGroundClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 52,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 53,
+      "Climate": "EldinUnderGroundClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 54,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 55,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 56,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 57,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Underground.game__location__Location.gyml",
+      "AreaNumber": 58,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 59,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Underground.game__location__Location.gyml",
+      "AreaNumber": 60,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 61,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 62,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Underground.game__location__Location.gyml",
+      "AreaNumber": 63,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Underground.game__location__Location.gyml",
+      "AreaNumber": 64,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWetlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 65,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        },
+        {
+          "name": "Weapon_Lsword_047"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        },
+        {
+          "name": "Weapon_Sword_047"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_047"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 66,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 67,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Underground.game__location__Location.gyml",
+      "AreaNumber": 68,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWetlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 69,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 70,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 71,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Underground.game__location__Location.gyml",
+      "AreaNumber": 72,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 6.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Underground.game__location__Location.gyml",
+      "AreaNumber": 73,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 6.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 74,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 75,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 76,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Underground.game__location__Location.gyml",
+      "AreaNumber": 77,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 78,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 79,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_030",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_009",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 80,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Underground.game__location__Location.gyml",
+      "AreaNumber": 81,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 82,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 83,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Underground.game__location__Location.gyml",
+      "AreaNumber": 84,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Underground.game__location__Location.gyml",
+      "AreaNumber": 85,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_006",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_007",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_105",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_027"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_027"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_027"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 86,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_011",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Lizalfos_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_008",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_174",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_107",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_174"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Underground.game__location__Location.gyml",
+      "AreaNumber": 87,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Zombie_Junior",
+          "num": 6.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_029"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_029"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_029"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Underground.game__location__Location.gyml",
+      "AreaNumber": 88,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 89,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_025"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_025"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 90,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 91,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 92,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 93,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_041"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_041"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 94,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 95,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 96,
+      "Climate": "EldinUnderGroundClimateLv2",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 97,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 98,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Underground.game__location__Location.gyml",
+      "AreaNumber": 99,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Senior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_036",
+              "prob": 10
+            }
+          ],
+          "name": "Enemy_Moriblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_022",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_001",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_124",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 3,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_024"
+        },
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_024"
+        },
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_024"
+        },
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_124"
+        },
+        {
+          "name": "Weapon_Lsword_124"
+        },
+        {
+          "name": "Weapon_Spear_124"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_169"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Underground.game__location__Location.gyml",
+      "AreaNumber": 100,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_031"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_032"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Underground.game__location__Location.gyml",
+      "AreaNumber": 101,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Ice_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_027",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_003",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_006",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_113",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Ice",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 2,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_051"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_113"
+        },
+        {
+          "name": "Weapon_Lsword_113"
+        },
+        {
+          "name": "Weapon_Spear_113"
+        },
+        {
+          "name": "Weapon_Bow_035"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Underground.game__location__Location.gyml",
+      "AreaNumber": 102,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Zonau",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 103,
+      "Climate": "EldinUnderGroundClimateLv1",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 100
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 100
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 100
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 100
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_036"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 104,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Underground.game__location__Location.gyml",
+      "AreaNumber": 105,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Electric_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Electric_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_051"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Underground.game__location__Location.gyml",
+      "AreaNumber": 106,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_001",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_004",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_035",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_004",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_106",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_103",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_103",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Treant_Broadleaf_Dummy",
+          "num": 9.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AI",
+          "num": 30.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        },
+        {
+          "name": "Weapon_Spear_030"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_106"
+        },
+        {
+          "name": "Weapon_Lsword_106"
+        },
+        {
+          "name": "Weapon_Spear_106"
+        },
+        {
+          "name": "Weapon_Bow_001"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Underground.game__location__Location.gyml",
+      "AreaNumber": 107,
+      "Climate": "DefaultUndergroundClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Fire_Middle",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese_Fire_AllDay",
+          "num": 2.0
+        },
+        {
+          "bows": [
+            {
+              "name": "Weapon_Bow_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Bow_003",
+              "prob": 90
+            }
+          ],
+          "name": "Enemy_Bokoblin_Bone_Junior",
+          "num": 2.0,
+          "shields": [
+            {
+              "name": "Weapon_Shield_002",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Shield_005",
+              "prob": 90
+            }
+          ],
+          "weapons": [
+            {
+              "name": "Weapon_Sword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Lsword_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Spear_112",
+              "prob": 10
+            },
+            {
+              "name": "Weapon_Sword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Lsword_108",
+              "prob": 90
+            },
+            {
+              "name": "Weapon_Spear_108",
+              "prob": 90
+            }
+          ]
+        },
+        {
+          "name": "Enemy_Golem_Little_Fire",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Mogurudo_Baby_Junior",
+          "num": 18.0
+        }
+      ],
+      "EnemyLevel": 1,
+      "EnvSound": "UndergroundTemperate",
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        },
+        {
+          "name": "Weapon_Lsword_036"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_112"
+        },
+        {
+          "name": "Weapon_Lsword_112"
+        },
+        {
+          "name": "Weapon_Spear_112"
+        },
+        {
+          "name": "Weapon_Bow_002"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    }
+  ]
+}

--- a/tools/Sky.ecocat.json
+++ b/tools/Sky.ecocat.json
@@ -1,0 +1,15997 @@
+{
+  "byteOrder": 65534,
+  "Version": 4,
+  "RootNode": [
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 0,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "GerudoFrostSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 1,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 2,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 3,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 4,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 5,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 6,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 7,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Sky.game__location__Location.gyml",
+      "AreaNumber": 8,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 9,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/LakeHylia_Sky.game__location__Location.gyml",
+      "AreaNumber": 10,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Sky.game__location__Location.gyml",
+      "AreaNumber": 11,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 12,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 13,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Sky.game__location__Location.gyml",
+      "AreaNumber": 14,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 15,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Sky.game__location__Location.gyml",
+      "AreaNumber": 16,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 17,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 18,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 19,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulOutback_Sky.game__location__Location.gyml",
+      "AreaNumber": 20,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Sky.game__location__Location.gyml",
+      "AreaNumber": 21,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulOutback_Sky.game__location__Location.gyml",
+      "AreaNumber": 22,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 23,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 24,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 25,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 26,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 27,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 28,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 29,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 30,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 31,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 32,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 33,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Sky.game__location__Location.gyml",
+      "AreaNumber": 34,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 35,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 36,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 37,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LiveMountain_Sky.game__location__Location.gyml",
+      "AreaNumber": 38,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "FrostSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 39,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Sky.game__location__Location.gyml",
+      "AreaNumber": 40,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 41,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 42,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 43,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_DeathMountain_Sky.game__location__Location.gyml",
+      "AreaNumber": 44,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 45,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 46,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 47,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 48,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 49,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 50,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 51,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 52,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 53,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 54,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 55,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 56,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 57,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HateruSea_Sky.game__location__Location.gyml",
+      "AreaNumber": 58,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 59,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Sky.game__location__Location.gyml",
+      "AreaNumber": 60,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 61,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 62,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Sky.game__location__Location.gyml",
+      "AreaNumber": 63,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Sky.game__location__Location.gyml",
+      "AreaNumber": 64,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWetlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 65,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 66,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 67,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Sky.game__location__Location.gyml",
+      "AreaNumber": 68,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWetlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 69,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 70,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 71,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Sky.game__location__Location.gyml",
+      "AreaNumber": 72,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoHighlands_Sky.game__location__Location.gyml",
+      "AreaNumber": 73,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 74,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 75,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 76,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Sky.game__location__Location.gyml",
+      "AreaNumber": 77,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 78,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 79,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 80,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleHill_Sky.game__location__Location.gyml",
+      "AreaNumber": 81,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 82,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 0,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 83,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Sky.game__location__Location.gyml",
+      "AreaNumber": 84,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_LanayruWaterSources_Sky.game__location__Location.gyml",
+      "AreaNumber": 85,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_I",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Animal_Insect_B",
+          "num": 20.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 86,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_GerudoDesert_Sky.game__location__Location.gyml",
+      "AreaNumber": 87,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "GerudoSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Beamos_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HyruleForest_Sky.game__location__Location.gyml",
+      "AreaNumber": 88,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 89,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 90,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Tropical",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_M",
+          "num": 5.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_BalloonEnvelope_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TiltingDoll_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 91,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 92,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_T",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 15.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 15.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_WestHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 93,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SpringPiston_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 94,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "BeginningSkyClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Keese",
+          "num": 2.0
+        },
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_H",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_Insect_E",
+          "num": 8.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 95,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 96,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_G",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 5.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 97,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 98,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 99,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SlipBoard_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_HeburaMountains_Sky.game__location__Location.gyml",
+      "AreaNumber": 100,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Rito",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Rocket_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_TimerBomb_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TabantaFrontier_Sky.game__location__Location.gyml",
+      "AreaNumber": 101,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Ptarmigan_A",
+          "num": 8.0
+        }
+      ],
+      "Climate": "HebraSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Subarctic",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_N",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_C",
+          "num": 2.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 10.0
+        },
+        {
+          "name": "Animal_Insect_B",
+          "num": 10.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LiftGeneratorWing_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_LightMirror_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_SnowMachine_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_TamulPlateau_Sky.game__location__Location.gyml",
+      "AreaNumber": 102,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "Temperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Cart_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Chaser_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_GolemHead_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_Pile_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EastHateru_Sky.game__location__Location.gyml",
+      "AreaNumber": 103,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "WetTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AA",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Insect_G",
+          "num": 8.0
+        },
+        {
+          "name": "Animal_Insect_P",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_Cannon_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ControlStick_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlashLight_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapArea_EldinCanyon_Sky.game__location__Location.gyml",
+      "AreaNumber": 104,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Ptarmigan_B",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Crow_A",
+          "num": 4.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 1,
+      "EnvSound": "Arid",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_AB",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_Q",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Insect_T",
+          "num": 4.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "Goron",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_002"
+        },
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_002"
+        },
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_002"
+        },
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FastWheel_Capsule_B_01"
+        },
+        {
+          "name": "SpObj_LiftableWaterPump_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_101"
+        },
+        {
+          "name": "Weapon_Lsword_101"
+        },
+        {
+          "name": "Weapon_Spear_101"
+        },
+        {
+          "name": "Weapon_Bow_105"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_167"
+    },
+    {
+      "Area": "Work/Location/MapArea_FironeGrassland_Sky.game__location__Location.gyml",
+      "AreaNumber": 105,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_Heron_A",
+          "num": 1.0
+        },
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_Hawk_A",
+          "num": 3.0
+        },
+        {
+          "name": "Animal_WildDuck_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_A",
+          "num": 4.0
+        },
+        {
+          "name": "Animal_Pigeon_B",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Heron_B",
+          "num": 2.0
+        }
+      ],
+      "Climate": "ZonaiSkyClimate",
+      "Enemy": "",
+      "EnemyLevel": 2,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "Fish": [
+        {
+          "name": "Animal_Fish_M",
+          "num": 2.0
+        },
+        {
+          "name": "Animal_Fish_AA",
+          "num": 5.0
+        }
+      ],
+      "GrassCut": "",
+      "Insect": [
+        {
+          "name": "Animal_Insect_R",
+          "num": 15.0
+        },
+        {
+          "name": "Animal_Insect_I",
+          "num": 10.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_003"
+        },
+        {
+          "name": "Weapon_Lsword_002"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_003"
+        },
+        {
+          "name": "Weapon_Sword_002"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_003"
+        },
+        {
+          "name": "Weapon_Spear_002"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": [
+        {
+          "name": "Item_FishGet_M",
+          "num": 2.0
+        },
+        {
+          "name": "Item_FishGet_AA",
+          "num": 5.0
+        }
+      ],
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_ElectricBoxGenerator_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_EnergyBank_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_163"
+        },
+        {
+          "name": "Weapon_Lsword_163"
+        },
+        {
+          "name": "Weapon_Spear_163"
+        },
+        {
+          "name": "Weapon_Bow_106"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_168"
+    },
+    {
+      "Area": "Work/Location/MapRegion_HyrulePrairie_Sky.game__location__Location.gyml",
+      "AreaNumber": 106,
+      "AutoPlacementMaterial": [
+        {
+          "name": "Weapon_Sword_167",
+          "num": 1.0
+        }
+      ],
+      "Bird": [
+        {
+          "name": "Animal_SkyGull_A",
+          "num": 3.0
+        }
+      ],
+      "Climate": "BeginningSkyClimate",
+      "Enemy": [
+        {
+          "name": "Enemy_Chuchu_Ice_Junior",
+          "num": 1.0
+        },
+        {
+          "name": "Enemy_Chuchu_Junior",
+          "num": 1.0
+        }
+      ],
+      "EnemyLevel": 0,
+      "EnvSound": "SkyTemperate",
+      "FallFloorInsect": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 40.0
+        },
+        {
+          "name": "Animal_Insect_S",
+          "num": 60.0
+        }
+      ],
+      "GrassCut": [
+        {
+          "name": "Animal_Insect_H",
+          "num": 100.0
+        }
+      ],
+      "JunkBoxMgrParam": "Sometimes",
+      "NPCSageType": "None",
+      "NotDecayedLargeSwordList": [
+        {
+          "name": "Weapon_Lsword_001"
+        }
+      ],
+      "NotDecayedSmallSwordList": [
+        {
+          "name": "Weapon_Sword_001"
+        }
+      ],
+      "NotDecayedSpearList": [
+        {
+          "name": "Weapon_Spear_001"
+        }
+      ],
+      "RainBonusMaterial": [
+        {
+          "name": "Item_Ore_E",
+          "num": 5.0
+        },
+        {
+          "name": "Animal_Insect_A",
+          "num": 20.0
+        },
+        {
+          "name": "Item_Ore_F",
+          "num": 10.0
+        }
+      ],
+      "ResTeraMat": "",
+      "Seafood": "",
+      "SpObjCapsuleBlockMaster": [
+        {
+          "name": "SpObj_CookSet_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_FlameThrower_Capsule_A_01"
+        },
+        {
+          "name": "SpObj_WindGenerator_Capsule_A_01"
+        }
+      ],
+      "Weapon": [
+        {
+          "name": "Weapon_Sword_021"
+        },
+        {
+          "name": "Weapon_Lsword_020"
+        },
+        {
+          "name": "Weapon_Spear_021"
+        },
+        {
+          "name": "Weapon_Bow_104"
+        }
+      ],
+      "ZonauRobotHornActor": "Item_Enemy_166"
+    }
+  ]
+}


### PR DESCRIPTION
Add Possible weapons for Shadowy Depth Statues
- Checks for `Npc_MinusFieldGhost_000`
- Gets current FieldMapArea (using the beco files and beco.ts)
- Appends `names` and `ui_names` to `equip` and `ui_equip`
- Added Ecosystem files to `tools/`
- `HoldingWeaponType` are included with Weapon and object `hash_id` comments for a check
  - 1: `NotDecayedSmallSwordList` (`HoldingWeaponType` is normally undefined)
  - 2: `NotDecayedLargeSwordList`
  - 3: `NotDecayedSpearList`