### PR TITLE
Add Dockerfile, read raw romfs with zstd+sarc+byml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /radar
+COPY . .
+RUN npm install && npm install typescript -g
+RUN apt-get update && apt-get install -y zstd python3-pip && pip3 install sarc byml --break-system-packages
+CMD ./node_modules/.bin/ts-node ./build.ts -r /romfs -e ./tools && \
+    npm run dev

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A server for querying placement objects in *The Legend of Zelda: Tears of the Ki
 
 Run build.ts to generate a map database before starting the server for the first time.
 
+    ts-node build.ts -d ../totk/Banc
+
+This assumes the `totk/Banc` directory contains the YAML data object map files
+
     ts-node build.ts -r ../totk -e tools
 
 This assumes the `totk` directory contains the unaltered romfs contents.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A server for querying placement objects in *The Legend of Zelda: Tears of the Ki
 
 Run build.ts to generate a map database before starting the server for the first time.
 
-    ts-node build.ts -d ../totk/Banc
+    ts-node build.ts -r ../totk -e tools
 
-This assumes the `totk/Banc` directory contains the YAML data object map files
+This assumes the `totk` directory contains the unaltered romfs contents.
+
+For docker usage: `docker build -t radar .; docker run -it --rm --name radar -v /path/to/your/romfs:/romfs radar`
+
+It's possible to build the db within docker and copy it out for the server to use, if you'd rather not install the extraction tools used in build.ts on your local machine.

--- a/beco.ts
+++ b/beco.ts
@@ -28,9 +28,8 @@ export class Beco {
   // Offsets to row data, divided by 2 and relative to the start of the row section
   offsets: number[]; // u32, size num_rows
   segments: BecoSegment[][]; // Rows x Segments
-  constructor(file: string) {
+  constructor(buf: Buffer) {
     let little = true;
-    let buf = fs.readFileSync(file);
     let arr = new Uint8Array(buf.byteLength);
     buf.copy(arr, 0, 0, buf.byteLength);
     let dv = new DataView(arr.buffer);

--- a/build.ts
+++ b/build.ts
@@ -7,17 +7,22 @@ import { Beco } from './beco';
 
 let parseArgs = require('minimist');
 let argv = parseArgs(process.argv);
-if (!argv.e || !argv.r) {
-  console.log("Error: Must specify paths to directories with ");
+const validRomfsArgs = (argv.e && argv.r);
+const validFolderArgs = (argv.e && argv.b && argv.d);
+if (!validRomfsArgs && !validFolderArgs) {
+  console.log("Error: Must specify paths to directories with -e and either -r or (-b and -d)");
+  console.log("          -d Banc extracted YAML files");
+  console.log("          -b field map area beco files");
   console.log("          -e Ecosystem json files");
   console.log("          -r Bare game romfs");
-  console.log("       e.g. % ts-node build.ts -r path/to/romfs -e tools")
+  console.log("       e.g. % ts-node build.ts -d path/to/Banc -b path/to/beco -e path/to/Ecosystem")
+  console.log("        or: % ts-node build.ts -r path/to/romfs -e path/to/Ecosystem")
   process.exit(1);
 }
 const ecoPath = argv.e;
 const romfsPath = argv.r;
-const totkData = path.join(romfsPath, 'Banc');
-const becoPath = path.join(romfsPath, 'Ecosystem', 'FieldMapArea');
+const totkData = argv.d || path.join(romfsPath, 'Banc');
+const becoPath = argv.b || path.join(romfsPath, 'Ecosystem', 'FieldMapArea');
 
 fs.rmSync('map.db.tmp', { force: true });
 const db = sqlite3('map.db.tmp');


### PR DESCRIPTION
This changes how build.ts is called, and also fails if these tools aren't installed which might be a little controversial. Runtime is also increased since we'll decompress+decode on every re-import, but thankfully it doesn't seem too excessive to me.

Enables https://github.com/aquacluck/totk-objmap-docker